### PR TITLE
Feature: client-side caching

### DIFF
--- a/app/js/data/cache.js
+++ b/app/js/data/cache.js
@@ -1,0 +1,53 @@
+class Cache {
+  static keys = {
+    THEME: 'bingo-theme',
+    CURRENT_CARD: 'bingo-current-card'
+  };
+
+  static get(key) {
+    try {
+      return localStorage.getItem(key);
+    } catch (err) {
+      console.error('Cache read failed:', err);
+      return null;
+    }
+  }
+
+  static set(key, value) {
+    try {
+      localStorage.setItem(key, value);
+    } catch (err) {
+      console.error('Cache write failed:', err);
+    }
+  }
+
+  static remove(key) {
+    try {
+      localStorage.removeItem(key);
+    } catch (err) {
+      console.error('Cache remove failed:', err);
+    }
+  }
+
+  static getTheme() {
+    return this.get(this.keys.THEME);
+  }
+
+  static setTheme(theme) {
+    this.set(this.keys.THEME, theme);
+  }
+
+  static getCurrentCard() {
+    return this.get(this.keys.CURRENT_CARD);
+  }
+
+  static setCurrentCard(cardToken) {
+    this.set(this.keys.CURRENT_CARD, cardToken);
+  }
+
+  static clearCurrentCard() {
+    this.remove(this.keys.CURRENT_CARD);
+  }
+}
+
+export { Cache };

--- a/app/js/ui/base.js
+++ b/app/js/ui/base.js
@@ -1,3 +1,5 @@
+import { Cache } from '../data/cache.js';
+
 class AppBaseUI {
   constructor() {
     this.dataset_name = '';
@@ -105,11 +107,20 @@ class AppBaseUI {
 
   set_theme(newTheme) {
     if(newTheme !== 'dark' && newTheme !== 'light') {
-      newTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      // Check cache first, then system preference
+      const savedTheme = Cache.getTheme();
+      if (savedTheme && (savedTheme === 'dark' || savedTheme === 'light')) {
+        newTheme = savedTheme;
+      } else {
+        newTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      }
     }
 
     document.documentElement.setAttribute('data-bs-theme', newTheme);
     this.update_theme_icon(newTheme);
+
+    // Save theme preference to cache
+    Cache.setTheme(newTheme);
   }
 
   toggle_theme() {

--- a/app/js/ui/card.js
+++ b/app/js/ui/card.js
@@ -1,6 +1,7 @@
 import { AppBaseUI } from './base.js';
 
 import { Card } from '../data/card.js';
+import { Cache } from '../data/cache.js';
 import { Sensitivity } from '../data/enums.js';
 
 import {
@@ -31,6 +32,7 @@ class CardUI extends AppBaseUI {
 
     this.load_config()
       .then(this.load_form.bind(this))
+      .then(this.check_cached_card.bind(this))
       .then(this.bind_event_handlers.bind(this))
       .catch(err => {
         this.ui_toast('danger', err);
@@ -62,6 +64,21 @@ class CardUI extends AppBaseUI {
 
     this.toggle_loading_spinner(false);
     this.toggle_show_content(true);
+  }
+
+  async check_cached_card() {
+    const cachedCard = Cache.getCurrentCard();
+    if (cachedCard) {
+      try {
+        this.card = new Card();
+        this.card.deserialize(cachedCard);
+        this.render();
+        return;
+      } catch(err) {
+        console.error('Failed to load cached card:', err);
+        Cache.clearCurrentCard();
+      }
+    }
   }
 
   async import() {
@@ -115,11 +132,25 @@ class CardUI extends AppBaseUI {
       document.querySelector('button#copy-export').classList.add('collapse');
     }
 
+    // Save current card to cache
+    this.save_card_to_cache();
+
     this.toggle_prompt_result(true);
     this.toggle_prompt_form(false);
 
     this.toggle_loading_spinner(false);
     this.toggle_show_content(true);
+  }
+
+  save_card_to_cache() {
+    if (this.card && this.card.spaces) {
+      try {
+        const cardToken = this.card.serialize();
+        Cache.setCurrentCard(cardToken);
+      } catch(err) {
+        console.error('Failed to cache card:', err);
+      }
+    }
   }
 
   reload() {
@@ -202,6 +233,7 @@ class CardUI extends AppBaseUI {
     });
 
     document.querySelector('button#rebuild').addEventListener('click', (ev) => {
+      Cache.clearCurrentCard();
       this.toggle_prompt_form(true);
       this.toggle_prompt_result(false);
 
@@ -239,6 +271,8 @@ class CardUI extends AppBaseUI {
         target.classList.remove('marked-square');
       }
 
+      // Save updated card state to cache
+      this.save_card_to_cache();
       this.clearExport();
 
       ev.preventDefault();


### PR DESCRIPTION
Hi!
This PR adds client side caching for the following:
1) Dark/Light mode: When refreshing or re-loading the page now, the last saved theme (if any) will be used instead of defaulting to system preference.
2) Bingo Card: If there's a previously generated bingo card, it will be loaded first instead of jumping to the config screen. When you click "Build another", the cache will be cleared. I thought this would be helpful for those who tend to keep their tabs open all the time and don't want to keep reloading or saving the code when ticking off the boxes. 