### PR TITLE
Feature: Reroll card

### DIFF
--- a/app/css/application.css
+++ b/app/css/application.css
@@ -206,6 +206,17 @@ html[data-bs-theme="light"] bingo-square.marked-square {
       background: var(--match-color);
     }
 
+    &.long-press-active {
+      background-color: darkred;
+      transform-origin: center;
+      transform: scale(1.05);
+    }
+
+    & > .bingo-square-text {
+      /* prevent context menu from appearing when long-pressing on touch screens */
+      user-select: none;
+    }
+
     &[data-id="bingo-square-num-12"] {
       font-size: 4vmin;
       font-weight: bold;

--- a/app/css/application.css
+++ b/app/css/application.css
@@ -212,8 +212,11 @@ html[data-bs-theme="light"] bingo-square.marked-square {
       transform: scale(1.05);
     }
 
-    & > .bingo-square-text {
-      /* prevent context menu from appearing when long-pressing on touch screens */
+    & > .bingo-square-text-selectable {
+      user-select: auto;
+    }
+
+    & > .bingo-square-text-unselectable {
       user-select: none;
     }
 

--- a/app/index.html
+++ b/app/index.html
@@ -298,7 +298,7 @@
             </div>
           </div>
           <div>
-            <h4>How to Re-Roll Specific Cards</h4>
+            <h4>How to Re-Roll Specific Squares</h4>
             <p>
               If you are generally happy with your bingo card but want to re-roll a specific square,
               you can click the button "Enable Re-roll" to enable re-rolling mode.

--- a/app/index.html
+++ b/app/index.html
@@ -287,8 +287,25 @@
                 Build Another
               </button>
             </div>
+            <div class="mx-auto center">
+              <button
+                class="w-80 btn btn-primary zaddy btn-lg"
+                type="button"
+                id="enable-reroll"
+              >
+                Enable Re-roll
+              </button>
+            </div>
           </div>
           <div>
+            <h4>How to Re-Roll Specific Cards</h4>
+            <p>
+              If you are generally happy with your bingo card but want to re-roll a specific square,
+              you can click the button "Enable Re-roll" to enable re-rolling mode.
+              Then, long press on the card square you want to change.
+              This will trigger the re-roll action and replace the card with a new one.
+              To exit re-roll mode, simply click the "Disable Re-roll" button.
+            </p>
             <h4>How to play Bingo</h4>
             <p>
               In your medium of choice, create stuff that vibes with the boxes

--- a/app/js/data/card.js
+++ b/app/js/data/card.js
@@ -80,6 +80,7 @@ class Card {
     Object.seal(this.spaces);
 
     this.pool = new Pool(this.sensitivity_limit, this.banned_flags, this.dataset);
+    this.pool.generateNew();
     const start = this.pool.spaces.slice(0, 12);
     const freespace = new Entry('FREE', [], 1, 'S', true);
     const end = this.pool.spaces.slice(11);
@@ -111,7 +112,7 @@ class Card {
     return btoa(payload);
   }
 
-  deserialize(payload) {
+  async deserialize(payload) {
     payload = atob(payload);
 
     const saved_card = JSON.parse(payload);
@@ -127,6 +128,49 @@ class Card {
       this.spaces[i] = Entry.deserialize(space);
       this.spaces[i].index = i;
     });
+
+    // Rebuild the pool for reroll functionality
+    await this.load_dataset();
+    this.rebuildPool();
+  }
+
+  // Rebuild pool from given card state
+  rebuildPool() {
+    this.pool = new Pool(this.sensitivity_limit, this.banned_flags, this.dataset);
+    this.pool.regenerateFromCardData(this.spaces);
+  }
+
+  // Reroll a single square at the given card index
+  rerollSquare(cardIndex) {
+    if (!this.pool) {
+      throw new Error('Card not built yet');
+    }
+
+    if (cardIndex < 0 || cardIndex >= 25) {
+      throw new Error('Invalid card index');
+    }
+
+    if (cardIndex === 12) {
+      throw new Error('Cannot reroll FREE space');
+    }
+
+    // Map card index to pool index
+    let poolIndex;
+    if (cardIndex < 12) {
+      poolIndex = cardIndex; // Card 0-11 -> Pool 0-11
+    } else if (cardIndex > 12) {
+      poolIndex = cardIndex - 1; // Card 13-24 -> Pool 12-23
+    }
+
+    try {
+      const newEntry = this.pool.rerollPoolSpace(poolIndex);
+      this.spaces[cardIndex] = newEntry;
+      this.spaces[cardIndex].index = cardIndex;
+
+      return newEntry;
+    } catch (error) {
+      throw new Error('No alternative entries available for reroll');
+    }
   }
 }
 

--- a/app/js/data/pool.js
+++ b/app/js/data/pool.js
@@ -83,8 +83,7 @@ class Pool {
     });
 
     // For each card space (excluding FREE), find matching entry in contents and mark as used
-    let poolIndex = 0;
-    for (let cardIndex = 0; cardIndex < 25; cardIndex++) {
+    for (let cardIndex = 0, poolIndex = 0; cardIndex < 25; cardIndex++) {
       if (cardIndex === 12) continue; // Skip FREE space
 
       const cardEntry = cardSpaces[cardIndex];

--- a/app/js/data/pool.js
+++ b/app/js/data/pool.js
@@ -66,8 +66,7 @@ class Pool {
   generateNew() {
     this.seed = this.genSeed();
 
-    let i = 0;
-    for(let slot = 0; slot < 24; slot++) {
+    for(let slot = 0, i = 0; slot < 24; slot++) {
       const initial_offset = (this.seed[slot] + i) % this.contents.length;
       const offset = (initial_offset + this.getNextValidReservation(initial_offset)) % (this.contents.length - 1);
       this.spaces[slot] = this.contents[offset].entry;

--- a/app/js/data/pool.js
+++ b/app/js/data/pool.js
@@ -41,10 +41,9 @@ class Pool {
       })
     }
 
+    // contents contains the entries with the weights applied.
+    // eg. (A, weight 3), (B, weight 1) => contents = [A, A, A, B]
     this.contents = entries.map((entry) => PoolReservation.getReservations(entry)).flat();
-    this.seed = this.genSeed();
-
-    this.generate();
   }
 
   genSeed() {
@@ -63,13 +62,80 @@ class Pool {
     throw new Error('All reservations exhausted');
   }
 
-  generate() {
+  // Generate new random card prompts for each slot given filtered contents.
+  generateNew() {
+    this.seed = this.genSeed();
+
     let i = 0;
     for(let slot = 0; slot < 24; slot++) {
       const initial_offset = (this.seed[slot] + i) % this.contents.length;
       const offset = (initial_offset + this.getNextValidReservation(initial_offset)) % (this.contents.length - 1);
       this.spaces[slot] = this.contents[offset].entry;
       this.spaces[slot].used = true;
+    }
+  }
+
+  // Re-generate pool spaces from loaded card data
+  regenerateFromCardData(cardSpaces) {
+    // Reset all entries to unused
+    this.contents.forEach(reservation => {
+      reservation.entry.used = false;
+    });
+
+    // For each card space (excluding FREE), find matching entry in contents and mark as used
+    let poolIndex = 0;
+    for (let cardIndex = 0; cardIndex < 25; cardIndex++) {
+      if (cardIndex === 12) continue; // Skip FREE space
+
+      const cardEntry = cardSpaces[cardIndex];
+
+      // Find matching entry in contents by text
+      const matchingReservation = this.contents.find(reservation =>
+        reservation.entry.text === cardEntry.text
+      );
+
+      if (matchingReservation) {
+        this.spaces[poolIndex] = matchingReservation.entry;
+        matchingReservation.entry.used = true;
+      } else {
+        console.warn(`Could not find matching entry for: ${cardEntry.text} - entry may have been removed from dataset`);
+        // Continue without this entry, it will be undefined in this.spaces[poolIndex]
+      }
+      poolIndex++;
+    }
+  }
+
+  // Reroll a specific pool space given a slot number and update the pool's spaces array
+  rerollPoolSpace(slot) {
+    if (slot < 0 || slot >= 24) {
+      throw new Error('Invalid pool index');
+    }
+
+    const currentEntry = this.spaces[slot];
+
+    // Generate a random starting position
+    const randomSeed = new Uint32Array(1);
+    self.crypto.getRandomValues(randomSeed);
+    const initial_offset = randomSeed[0] % this.contents.length;
+
+    try {
+      const offset = (initial_offset + this.getNextValidReservation(initial_offset)) % (this.contents.length - 1);
+      const newEntry = this.contents[offset].entry;
+
+      // Update pool's spaces array
+      this.spaces[slot] = newEntry;
+      this.spaces[slot].used = true;
+
+      // Handle case where current entry might be undefined (from missing dataset entries)
+      if (currentEntry) {
+        // Set previous entry to unused only after generating a new entry.
+        // This is to prevent regenerating the same entry.
+        currentEntry.used = false;
+      }
+
+      return newEntry;
+    } catch (error) {
+      throw error;
     }
   }
 }

--- a/app/js/data/pool.js
+++ b/app/js/data/pool.js
@@ -116,25 +116,22 @@ class Pool {
     self.crypto.getRandomValues(randomSeed);
     const initial_offset = randomSeed[0] % this.contents.length;
 
-    try {
-      const offset = (initial_offset + this.getNextValidReservation(initial_offset)) % (this.contents.length - 1);
-      const newEntry = this.contents[offset].entry;
+    const offset = (initial_offset + this.getNextValidReservation(initial_offset)) % (this.contents.length - 1);
+    const newEntry = this.contents[offset].entry;
 
-      // Update pool's spaces array
-      this.spaces[slot] = newEntry;
-      this.spaces[slot].used = true;
+    // Update pool's spaces array
+    this.spaces[slot] = newEntry;
+    this.spaces[slot].used = true;
 
-      // Handle case where current entry might be undefined (from missing dataset entries)
-      if (currentEntry) {
-        // Set previous entry to unused only after generating a new entry.
-        // This is to prevent regenerating the same entry.
-        currentEntry.used = false;
-      }
-
-      return newEntry;
-    } catch (error) {
-      throw error;
+    // Handle case where current entry might be undefined (from missing dataset entries)
+    if (currentEntry) {
+      // Set previous entry to unused only after generating a new entry.
+      // This is to prevent regenerating the same entry.
+      currentEntry.used = false;
+    } else {
+      console.warn('Encountered undefined entry; entry may have been removed from dataset');
     }
+    return newEntry;
   }
 }
 

--- a/app/js/elems.js
+++ b/app/js/elems.js
@@ -79,7 +79,7 @@ class SensitivityElem extends UIElement {
   }
 
   render() {
-    return `<${this.tag} data-id="sensitivity-${this.data}">${this.data}</${this.tag}`;
+    return `<${this.tag} data-id="sensitivity-${this.data}">${this.data}</${this.tag}>`;
   }
 }
 
@@ -121,10 +121,10 @@ class BingoSquareElem extends UIElement {
     return `sensitivity-${this.data.sensitivity.description}`;
   }
 
-  render() {
+  render(long_press_enabled = false) {
     return `
     <${this.tag} class="is-bingo-square ${this.get_marked_class()} ${this.get_sensitivity_class()}" data-id="bingo-square-num-${this.data.index}">
-      <div class="text-responsive text-center text-break bingo-square-text">${this.data.text}</div>
+      <div class="text-responsive text-center text-break bingo-square-text ${long_press_enabled ? 'bingo-square-text-unselectable' : 'bingo-square-text-selectable'}">${this.data.text}</div>
     </${this.tag}>`;
   }
 }

--- a/app/js/elems.js
+++ b/app/js/elems.js
@@ -124,7 +124,7 @@ class BingoSquareElem extends UIElement {
   render() {
     return `
     <${this.tag} class="is-bingo-square ${this.get_marked_class()} ${this.get_sensitivity_class()}" data-id="bingo-square-num-${this.data.index}">
-      <div class="text-responsive text-center text-break">${this.data.text}</div>
+      <div class="text-responsive text-center text-break bingo-square-text">${this.data.text}</div>
     </${this.tag}>`;
   }
 }

--- a/app/js/ui/card.js
+++ b/app/js/ui/card.js
@@ -29,6 +29,8 @@ class CardUI extends AppBaseUI {
     this.flag_opt_elem = new FlagElem(this, this.flag_opt_hoist);
     this.bingo_square_elem = new BingoSquareElem(this, this.bingo_hoist);
 
+    this.long_press_enabled = false;
+
     this.load_config()
       .then(this.load_form.bind(this))
       .then(this.bind_event_handlers.bind(this))
@@ -106,7 +108,7 @@ class CardUI extends AppBaseUI {
       if ((i++ % 5) === 0) {
         this.bingo_square_elem.set_force_col_break();
       }
-      this.bingo_square_elem.display();
+      this.bingo_square_elem.display(this.long_press_enabled);
     });
 
     this.clearExport();
@@ -129,7 +131,7 @@ class CardUI extends AppBaseUI {
       const newEntry = this.card.rerollSquare(id);
 
       this.bingo_square_elem.update(newEntry);
-      this.bingo_square_elem.display();
+      this.bingo_square_elem.display(this.long_press_enabled);
 
       this.clearExport();
 
@@ -163,6 +165,27 @@ class CardUI extends AppBaseUI {
       document.querySelector('#prompt-result').classList.remove('collapse');
     } else {
       document.querySelector('#prompt-result').classList.add('collapse');
+    }
+  }
+
+  toggleEnableRerollButton(ev) {
+    const rerollButton = ev.target;
+    if (rerollButton.innerText.includes('Enable Re-roll')) {
+      rerollButton.innerText = 'Disable Re-roll';
+      this.ui_toast('info', 'Re-roll enabled! Long press a square to re-roll it.');
+      this.long_press_enabled = true;
+      document.querySelectorAll("#bingo-frame>bingo-square>.bingo-square-text").forEach(el => {
+        el.classList.remove('bingo-square-text-selectable');
+        el.classList.add('bingo-square-text-unselectable');
+      })
+    } else {
+      rerollButton.innerText = 'Enable Re-roll';
+      this.ui_toast('info', 'Re-roll disabled.');
+      this.long_press_enabled = false;
+      document.querySelectorAll("#bingo-frame>bingo-square>.bingo-square-text").forEach(el => {
+        el.classList.remove('bingo-square-text-unselectable');
+        el.classList.add('bingo-square-text-selectable');
+      })
     }
   }
 
@@ -222,6 +245,11 @@ class CardUI extends AppBaseUI {
         });
     });
 
+    document.querySelector('button#enable-reroll').addEventListener('click', (ev) => {
+      this.toggleEnableRerollButton(ev);
+      ev.preventDefault();
+    });
+
     document.querySelector('button#rebuild').addEventListener('click', (ev) => {
       this.toggle_prompt_form(true);
       this.toggle_prompt_result(false);
@@ -255,6 +283,7 @@ class CardUI extends AppBaseUI {
 
     // Handle long press on mousedown/touchstart
     const handleLongPress = (ev) => {
+      if (!this.long_press_enabled) return;
       const target = getBingoSquareTarget(ev);
       if (!target) return;
 

--- a/app/js/ui/card.js
+++ b/app/js/ui/card.js
@@ -68,7 +68,7 @@ class CardUI extends AppBaseUI {
     this.card = new Card();
 
     try {
-      this.card.deserialize(this.import_hoist.value);
+      await this.card.deserialize(this.import_hoist.value);
     } catch(err) {
       console.error(err);
       this.ui_toast('danger', 'Import failed');
@@ -120,6 +120,27 @@ class CardUI extends AppBaseUI {
 
     this.toggle_loading_spinner(false);
     this.toggle_show_content(true);
+  }
+
+  handleReroll(target) {
+    const id = parseInt(target.getAttribute('data-id').split('-').slice(-1)[0]);
+
+    try {
+      const newEntry = this.card.rerollSquare(id);
+
+      this.bingo_square_elem.update(newEntry);
+      this.bingo_square_elem.display();
+
+      this.clearExport();
+
+      target.classList.remove('long-press-active');
+      this.ui_toast('success', 'Square rerolled!');
+
+    } catch (error) {
+      console.error('Reroll failed:', error);
+      target.classList.remove('long-press-active');
+      this.ui_toast('warning', error.message);
+    }
   }
 
   reload() {
@@ -220,16 +241,55 @@ class CardUI extends AppBaseUI {
       ev.preventDefault();
     });
 
-    this.bingo_hoist.addEventListener('click', (ev) => {
-      let target = null;
+    // Reroll card if long press reaches 1s
+    let longPressTimer = null;
+
+    const getBingoSquareTarget = (ev) => {
       if (ev.target.classList.contains('is-bingo-square')) {
-        target = ev.target;
+        return ev.target;
       } else if (ev.target.parentNode.classList.contains('is-bingo-square')) {
-        target = ev.target.parentNode;
-      } else {
-        return;
+        return ev.target.parentNode;
+      }
+      return null;
+    };
+
+    // Handle long press on mousedown/touchstart
+    const handleLongPress = (ev) => {
+      const target = getBingoSquareTarget(ev);
+      if (!target) return;
+
+      target.classList.add('long-press-active');
+
+      longPressTimer = setTimeout(() => {
+        this.handleReroll(target);
+      }, 1000);
+    };
+
+    this.bingo_hoist.addEventListener('mousedown', handleLongPress);
+    this.bingo_hoist.addEventListener('touchstart', handleLongPress, { passive: true });
+
+    // Cancel long press on mouseup/mouseout/touchend/mouseleave
+    const cancelLongPress = (ev) => {
+      if (longPressTimer) {
+        clearTimeout(longPressTimer);
+        longPressTimer = null;
       }
 
+      const target = getBingoSquareTarget(ev);
+      if (target) {
+        target.classList.remove('long-press-active');
+      }
+    };
+
+    this.bingo_hoist.addEventListener('mouseup', cancelLongPress);
+    this.bingo_hoist.addEventListener('mouseout', cancelLongPress);
+    this.bingo_hoist.addEventListener('touchend', cancelLongPress);
+    this.bingo_hoist.addEventListener('mouseleave', cancelLongPress);
+
+    // Regular click handler: Toggle square completion
+    this.bingo_hoist.addEventListener('click', (ev) => {
+      const target = getBingoSquareTarget(ev);
+      if (!target) return;
       const id = target.getAttribute('data-id').split('-').slice(-1);
       const marked = this.card.spaces[id].mark();
 


### PR DESCRIPTION
Quite a fair bit of things happening, I think:
- On both PC and phones, you can long press for one second with a mouse left button or touchscreen on a specific square and it should reroll.
- Reconstruct pool when loading from the exported code, so that a loaded card can have re-rolled squares too. I recall the dataset may rename some topics, so I added a case to handle when the topic doesn't exist anymore (it will simply just skip it). When the new topic is selected, the old topic on that square will be marked as "unused" so if you re-roll multiple times, you may end back up on that same topic.
- Added a `user-select: none;` so that when you long press on a square using a phone, and your finger is directly on top of the words, it doesn't also select the words and open up a menu for you to copy the words or google search it.